### PR TITLE
8368166: Media query should accept multiple rules

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
@@ -4324,19 +4324,26 @@ final public class CssParser {
 
             stylesheet.getRules().add(new Rule(mediaRule, selectors, declarations));
 
+            Token lastToken = currentToken;
             currentToken = nextToken(lexer);
 
-            while (expectedRBraces > 0) {
-                if (!consumeRBrace(lexer)) {
-                    return;
-                }
-
-                if (mediaRule != null) {
-                    mediaRule = mediaRule.getParent();
-                }
-
+            while (expectedRBraces > 0 && currentToken != null && currentToken.getType() == CssLexer.RBRACE) {
+                mediaRule = mediaRule.getParent();
+                lastToken = currentToken;
                 currentToken = nextToken(lexer);
                 expectedRBraces--;
+            }
+
+            if (expectedRBraces > 0 && currentToken != null && currentToken.getType() == Token.EOF) {
+                String msg = String.format("Expected RBRACE at [%d,%d]", lastToken.getLine(), lastToken.getOffset() + 1);
+                ParseError error = createError(msg);
+                if (LOGGER.isLoggable(Level.WARNING)) {
+                    LOGGER.warning(error.toString());
+                }
+
+                reportError(error);
+                currentToken = null;
+                return;
             }
         }
 
@@ -4360,25 +4367,6 @@ final public class CssParser {
                 && currentToken.getType() != CssLexer.RBRACE) {
             // Skip forward to the next SEMI or RBRACE.
         }
-    }
-
-    private boolean consumeRBrace(CssLexer lexer) {
-        if (currentToken == null || currentToken.getType() != CssLexer.RBRACE) {
-            int line = currentToken != null ? currentToken.getLine() : -1;
-            int pos = currentToken != null ? currentToken.getOffset() : -1;
-            String msg = String.format("Expected RBRACE at [%d,%d]", line, pos);
-            ParseError error = createError(msg);
-            if (LOGGER.isLoggable(Level.WARNING)) {
-                LOGGER.warning(error.toString());
-            }
-
-            reportError(error);
-            currentToken = null;
-            return false;
-        }
-
-        currentToken = lexer.nextToken();
-        return true;
     }
 
     private MediaRule mediaRule(CssLexer lexer, MediaRule mediaRule) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a176dad2](https://github.com/openjdk/jfx/commit/a176dad2a2da9f0fac25c6b0ff2028b49f59a526) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Michael Strauß on 3 Oct 2025 and was reviewed by Andy Goryachev and Ambarish Rapte.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8368166](https://bugs.openjdk.org/browse/JDK-8368166) needs maintainer approval

### Issue
 * [JDK-8368166](https://bugs.openjdk.org/browse/JDK-8368166): Media query should accept multiple rules (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx25u.git pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/jfx25u.git pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx25u/pull/21.diff">https://git.openjdk.org/jfx25u/pull/21.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx25u/pull/21#issuecomment-3365210610)
</details>
