### PR TITLE
8368691: Update libxml2 to 2.14.6

### DIFF
--- a/modules/javafx.web/src/main/legal/libxml2.md
+++ b/modules/javafx.web/src/main/legal/libxml2.md
@@ -1,4 +1,4 @@
-## xmlsoft.org: libxml2 v2.14.5
+## xmlsoft.org: libxml2 v2.14.6
 
 ### libxml2 License
 ```

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/config.h
@@ -83,7 +83,7 @@
 #define PACKAGE_NAME "libxml2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxml2 2.14.5"
+#define PACKAGE_STRING "libxml2 2.14.6"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxml2"
@@ -92,7 +92,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.14.5"
+#define PACKAGE_VERSION "2.14.6"
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -100,7 +100,7 @@
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "2.14.5"
+#define VERSION "2.14.6"
 
 /* System configuration directory (/etc) */
 #define XML_SYSCONFDIR "/usr/local/etc"

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
@@ -15,21 +15,21 @@
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.14.5"
+#define LIBXML_DOTTED_VERSION "2.14.6"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21405
+#define LIBXML_VERSION 21406
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21306"
+#define LIBXML_VERSION_STRING "21406"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -44,7 +44,7 @@
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21405);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21406);
 
 /**
  * LIBXML_THREAD_ENABLED:

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/config.h
@@ -25,10 +25,10 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1
 
-/* Define if history library is there (-lhistory) */
+/* Define if history library is available */
 /* #undef HAVE_LIBHISTORY */
 
-/* Define if readline library is there (-lreadline) */
+/* Define if readline library is available */
 /* #undef HAVE_LIBREADLINE */
 
 /* Define to 1 if you have the <lzma.h> header file. */
@@ -83,7 +83,7 @@
 #define PACKAGE_NAME "libxml2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxml2 2.14.5"
+#define PACKAGE_STRING "libxml2 2.14.6"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxml2"
@@ -92,7 +92,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.14.5"
+#define PACKAGE_VERSION "2.14.6"
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -100,7 +100,7 @@
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "2.14.5"
+#define VERSION "2.14.6"
 
 /* System configuration directory (/etc) */
 #define XML_SYSCONFDIR "/usr/local/etc"

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
@@ -15,21 +15,21 @@
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.14.5"
+#define LIBXML_DOTTED_VERSION "2.14.6"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21405
+#define LIBXML_VERSION 21406
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21405"
+#define LIBXML_VERSION_STRING "21406"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -44,7 +44,7 @@
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21405);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21406);
 
 /**
  * LIBXML_THREAD_ENABLED:
@@ -243,11 +243,9 @@
 /**
  * LIBXML_UNICODE_ENABLED:
  *
- * Whether the Unicode related interfaces are compiled in
+ * Removed in 2.14
  */
-#if 0
-#define LIBXML_UNICODE_ENABLED
-#endif
+#undef LIBXML_UNICODE_ENABLED
 
 /**
  * LIBXML_REGEXP_ENABLED:
@@ -297,7 +295,7 @@
  *
  * the string suffix used by dynamic modules (usually shared libraries)
  */
-#define LIBXML_MODULE_EXTENSION ""
+#define LIBXML_MODULE_EXTENSION ".so"
 #endif
 
 /**

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
@@ -1,5 +1,25 @@
 NEWS file for libxml2
 
+v2.14.6: Sep 8 2025
+
+### Regressions
+
+- valid: Don't add ids when validating entity content
+- Fix initGenericErrorDefaultFunc(NULL) (Samuel Thibault)
+- valid: Undeprecate xmlAdd*Decl
+- globals: Include HTMLparser.h, fixing Windows build
+- io: Fix reading from pipes like stdin on Windows
+
+### Security
+
+- regexp: Avoid integer overflow and OOB array access
+- tree: Guard against atype corruption
+
+### Improvements
+
+- parser: Fix xmlSaturatedAddSizeT argument type
+
+
 v2.14.5: Jul 10 2025
 
 ### Regressions

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/SAX2.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/SAX2.c
@@ -1184,8 +1184,19 @@ xmlSAX1Attribute(xmlParserCtxtPtr ctxt, const xmlChar *fullname,
                 xmlFree(val);
             }
         } else {
+            /*
+             * When replacing entities, make sure that IDs in
+             * entities aren't registered. This also shouldn't be
+             * done when entities aren't replaced, but this would
+             * require to rework IDREF checks.
+             */
+            if (ctxt->input->entity != NULL)
+                ctxt->vctxt.flags |= XML_VCTXT_IN_ENTITY;
+
             ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt, ctxt->myDoc,
                                                ctxt->node, ret, value);
+
+            ctxt->vctxt.flags &= ~XML_VCTXT_IN_ENTITY;
         }
     } else
 #endif /* LIBXML_VALID_ENABLED */
@@ -2052,8 +2063,19 @@ xmlSAX2AttributeNs(xmlParserCtxtPtr ctxt,
             if (dup == NULL)
                 xmlSAX2ErrMemory(ctxt);
 
+            /*
+             * When replacing entities, make sure that IDs in
+             * entities aren't registered. This also shouldn't be
+             * done when entities aren't replaced, but this would
+             * require to rework IDREF checks.
+             */
+            if (ctxt->input->entity != NULL)
+                ctxt->vctxt.flags |= XML_VCTXT_IN_ENTITY;
+
             ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
                                      ctxt->myDoc, ctxt->node, ret, dup);
+
+            ctxt->vctxt.flags &= ~XML_VCTXT_IN_ENTITY;
         }
     } else
 #endif /* LIBXML_VALID_ENABLED */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/globals.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/globals.c
@@ -18,6 +18,7 @@
 #include <libxml/xmlerror.h>
 #include <libxml/xmlmemory.h>
 #include <libxml/xmlIO.h>
+#include <libxml/HTMLparser.h>
 #include <libxml/parser.h>
 #include <libxml/threads.h>
 #include <libxml/tree.h>

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/valid.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/valid.h
@@ -139,7 +139,6 @@ typedef struct _xmlHashTable xmlRefTable;
 typedef xmlRefTable *xmlRefTablePtr;
 
 /* Notation */
-XML_DEPRECATED
 XMLPUBFUN xmlNotationPtr
                 xmlAddNotationDecl      (xmlValidCtxtPtr ctxt,
                                          xmlDtdPtr dtd,
@@ -204,7 +203,6 @@ XMLPUBFUN void
 #endif /* LIBXML_OUTPUT_ENABLED */
 
 /* Element */
-XML_DEPRECATED
 XMLPUBFUN xmlElementPtr
                 xmlAddElementDecl       (xmlValidCtxtPtr ctxt,
                                          xmlDtdPtr dtd,
@@ -240,7 +238,6 @@ XMLPUBFUN xmlEnumerationPtr
                 xmlCopyEnumeration      (xmlEnumerationPtr cur);
 
 /* Attribute */
-XML_DEPRECATED
 XMLPUBFUN xmlAttributePtr
                 xmlAddAttributeDecl     (xmlValidCtxtPtr ctxt,
                                          xmlDtdPtr dtd,

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xmlerror.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xmlerror.h
@@ -20,7 +20,7 @@ extern "C" {
  * Backward compatibility
  */
 #define initGenericErrorDefaultFunc(h) \
-    xmlSetGenericErrorFunc(NULL, (h) ? *(h) : NULL)
+    xmlSetGenericErrorFunc(NULL, (h) ? *((xmlGenericErrorFunc *) (h)) : NULL)
 
 /**
  * xmlErrorLevel:

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/private/parser.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/private/parser.h
@@ -20,6 +20,10 @@
  * Set if the validation context is part of a parser context.
  */
 #define XML_VCTXT_USE_PCTXT (1u << 1)
+/**
+ * Set when parsing entities.
+ */
+#define XML_VCTXT_IN_ENTITY (1u << 3)
 
 /*
  * TODO: Rename to avoid confusion with xmlParserInputFlags

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parser.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parser.c
@@ -413,7 +413,7 @@ xmlSaturatedAdd(unsigned long *dst, unsigned long val) {
 }
 
 static void
-xmlSaturatedAddSizeT(unsigned long *dst, unsigned long val) {
+xmlSaturatedAddSizeT(unsigned long *dst, size_t val) {
     if (val > ULONG_MAX - *dst)
         *dst = ULONG_MAX;
     else

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/tree.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/tree.c
@@ -1892,8 +1892,8 @@ xmlFreeProp(xmlAttrPtr cur) {
         xmlDeregisterNodeDefaultValue((xmlNodePtr)cur);
 
     /* Check for ID removal -> leading to invalid references ! */
-    if ((cur->doc != NULL) && (cur->atype == XML_ATTRIBUTE_ID)) {
-            xmlRemoveID(cur->doc, cur);
+    if (cur->doc != NULL && cur->id != NULL) {
+        xmlRemoveID(cur->doc, cur);
     }
     if (cur->children != NULL) xmlFreeNodeList(cur->children);
     DICT_FREE(cur->name)
@@ -2736,7 +2736,7 @@ xmlNodeSetDoc(xmlNodePtr node, xmlDocPtr doc) {
              * TODO: ID attributes should also be added to the new
              * document, but it's not clear how to handle clashes.
              */
-            if (attr->atype == XML_ATTRIBUTE_ID)
+            if (attr->id != NULL)
                 xmlRemoveID(oldDoc, attr);
 
             break;
@@ -6919,7 +6919,7 @@ xmlSetNsProp(xmlNodePtr node, xmlNsPtr ns, const xmlChar *name,
                 return(NULL);
         }
 
-        if (prop->atype == XML_ATTRIBUTE_ID) {
+        if (prop->id != NULL) {
             xmlRemoveID(node->doc, prop);
             prop->atype = XML_ATTRIBUTE_ID;
         }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/valid.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/valid.c
@@ -1139,8 +1139,6 @@ xmlFreeElement(xmlElementPtr elem) {
  * @type:  the element type
  * @content:  the element content tree or NULL
  *
- * DEPRECATED: Internal function, don't use.
- *
  * Register a new element declaration
  *
  * Returns NULL if not, otherwise the entity
@@ -1651,8 +1649,6 @@ xmlFreeAttribute(xmlAttributePtr attr) {
  * @defaultValue:  the attribute default value
  * @tree:  if it's an enumeration, the associated list
  *
- * DEPRECATED: Internal function, don't use.
- *
  * Register a new attribute declaration
  * Note that @tree becomes the ownership of the DTD
  *
@@ -2063,8 +2059,6 @@ xmlFreeNotation(xmlNotationPtr nota) {
  * @name:  the entity name
  * @PublicID:  the public identifier or NULL
  * @SystemID:  the system identifier or NULL
- *
- * DEPRECATED: Internal function, don't use.
  *
  * Register a new notation declaration
  *
@@ -4296,7 +4290,7 @@ xmlValidateOneAttribute(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
                attr->name, elem->name, NULL);
         return(0);
     }
-    if (attr->atype == XML_ATTRIBUTE_ID)
+    if (attr->id != NULL)
         xmlRemoveID(doc, attr);
     attr->atype = attrDecl->atype;
 
@@ -4319,7 +4313,8 @@ xmlValidateOneAttribute(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
     }
 
     /* Validity Constraint: ID uniqueness */
-    if (attrDecl->atype == XML_ATTRIBUTE_ID) {
+    if (attrDecl->atype == XML_ATTRIBUTE_ID &&
+        (ctxt == NULL || (ctxt->flags & XML_VCTXT_IN_ENTITY) == 0)) {
         if (xmlAddID(ctxt, doc, value, attr) == NULL)
             ret = 0;
     }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
@@ -15,21 +15,21 @@
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.14.5undefined"
+#define LIBXML_DOTTED_VERSION "2.14.6undefined"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21405
+#define LIBXML_VERSION 21406
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21405"
+#define LIBXML_VERSION_STRING "21406"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -44,7 +44,7 @@
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21405);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21406);
 
 /**
  * LIBXML_THREAD_ENABLED:


### PR DESCRIPTION
Clean Backport. Updated libxml2 to v2.14.6. Verified build and sanity on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8368691](https://bugs.openjdk.org/browse/JDK-8368691) needs maintainer approval

### Issue
 * [JDK-8368691](https://bugs.openjdk.org/browse/JDK-8368691): Update libxml2 to 2.14.6 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx25u.git pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.org/jfx25u.git pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx25u/pull/22.diff">https://git.openjdk.org/jfx25u/pull/22.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx25u/pull/22#issuecomment-3371644621)
</details>
