### PR TITLE
8371106: [macOS] Min/max window height is incorrect for EXTENDED StageStyle

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -54,6 +54,7 @@
     NSUInteger          enabledStyleMask; // valid while the window is disabled
     BOOL                isTransparent;
     BOOL                isDecorated;
+    BOOL                isExtended;
     BOOL                isResizable;
     BOOL                isStandardButtonsVisible;
     BOOL                suppressWindowMoveEvent;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -591,6 +591,7 @@ static jlong _createWindowCommonDo(JNIEnv *env, jobject jWindow, jlong jOwnerPtr
         }
 
         window->isDecorated = isTitled || isExtended;
+        window->isExtended = isExtended;
         window->isTransparent = isTransparent;
         window->isSizeAssigned = NO;
         window->isLocationAssigned = NO;
@@ -1212,7 +1213,13 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setMinimumSize
     GLASS_POOL_ENTER;
     {
         GlassWindow *window = getGlassWindow(env, jPtr);
-        [window->nsWindow setMinSize:NSMakeSize(jW, jH)];
+        NSSize minSize = NSMakeSize(jW, jH);
+
+        if (window->isExtended) {
+            window->nsWindow.contentMinSize = minSize;
+        } else {
+            [window->nsWindow setMinSize:minSize];
+        }
     }
     GLASS_POOL_EXIT;
     GLASS_CHECK_EXCEPTION(env);
@@ -1235,8 +1242,15 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setMaximumSize
     GLASS_POOL_ENTER;
     {
         GlassWindow *window = getGlassWindow(env, jPtr);
-        [window->nsWindow setMaxSize:NSMakeSize(jW == -1 ? FLT_MAX : (CGFloat)jW,
-                                                jH == -1 ? FLT_MAX : (CGFloat)jH)];
+        NSSize maxSize = NSMakeSize(
+            jW == -1 ? FLT_MAX : (CGFloat)jW,
+            jH == -1 ? FLT_MAX : (CGFloat)jH);
+
+        if (window->isExtended) {
+            window->nsWindow.contentMaxSize = maxSize;
+        } else {
+            [window->nsWindow setMaxSize:maxSize];
+        }
     }
     GLASS_POOL_EXIT;
     GLASS_CHECK_EXCEPTION(env);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [013e55b1](https://github.com/openjdk/jfx/commit/013e55b1ba687d212185d00167f375b816faf8c5) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Michael Strauß on 11 Nov 2025 and was reviewed by Andy Goryachev and Kevin Rushforth.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8371106](https://bugs.openjdk.org/browse/JDK-8371106) needs maintainer approval

### Issue
 * [JDK-8371106](https://bugs.openjdk.org/browse/JDK-8371106): [macOS] Min/max window height is incorrect for EXTENDED StageStyle (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx25u.git pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.org/jfx25u.git pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx25u/pull/41.diff">https://git.openjdk.org/jfx25u/pull/41.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx25u/pull/41#issuecomment-3677306917)
</details>
