### PR TITLE
8379209: Uninitialised variable in pathApplierFunctionFast of coretext.c

### DIFF
--- a/modules/javafx.graphics/src/main/native-font/coretext.c
+++ b/modules/javafx.graphics/src/main/native-font/coretext.c
@@ -1138,6 +1138,8 @@ void pathApplierFunctionFast(void *i, const CGPathElement *e) {
         type = 4;
         coordCount = 0;
         break;
+    default:
+        goto fail;
     }
     info->pointTypes[info->numTypes++] = type;
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [56ec1004](https://github.com/openjdk/jfx/commit/56ec1004052c752f464c39976c18e5afefa6fe1c) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Kevin Rushforth on 2 Apr 2026 and was reviewed by Ambarish Rapte and Jayathirth D V.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8379209](https://bugs.openjdk.org/browse/JDK-8379209) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8379209](https://bugs.openjdk.org/browse/JDK-8379209): Uninitialised variable in pathApplierFunctionFast of coretext.c (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx25u.git pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/jfx25u.git pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx25u/pull/58.diff">https://git.openjdk.org/jfx25u/pull/58.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx25u/pull/58#issuecomment-4594823267)
</details>
