### PR TITLE
8381517: GlassViewDelegate::convertNSStringToJString can return uninitialized value

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -1149,10 +1149,14 @@ static jstring convertNSStringToJString(id aString, int length)
 {
     GET_MAIN_JENV;
 
-    jstring jStr;
+    jstring jStr = NULL;
     if ([aString isKindOfClass:[NSAttributedString class]]) {
+        if (length <= 0 || length > SIZE_MAX / sizeof(jchar)) {
+            return NULL;
+        }
+
         NSData *data = [[aString string] dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
-        jchar *dataBytes = (jchar *)malloc(sizeof(jchar) * length);
+        jchar *dataBytes = (jchar *)malloc(sizeof(jchar) * (size_t)length);
         if (dataBytes != NULL) {
             [data getBytes:dataBytes length:length * 2];
             jStr = (*env)->NewString(env, dataBytes, length);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit c835a249 from the openjdk/jfx repository.

The commit being backported was authored by Kevin Rushforth on 2 Apr 2026 and was reviewed by Andy Goryachev and Jayathirth D V.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8381517](https://bugs.openjdk.org/browse/JDK-8381517) needs maintainer approval

### Issue
 * [JDK-8381517](https://bugs.openjdk.org/browse/JDK-8381517): GlassViewDelegate::convertNSStringToJString can return uninitialized value (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx25u.git pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.org/jfx25u.git pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx25u/pull/59.diff">https://git.openjdk.org/jfx25u/pull/59.diff</a>

</details>
