### PR TITLE
8389515: Memory leak in dshowwrapper - decoded buffers delivered by CSink are never unmapped

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,26 +55,29 @@ HRESULT CAllocator::GetBuffer(IMediaSample **ppBuffer, REFERENCE_TIME *pStartTim
     if (FAILED(hr))
         return hr;
 
+    pSample = (CSample*)*ppBuffer;
+
     if (m_pBuffer == NULL)
     {
         if (GetGstBuffer != NULL)
             GetGstBuffer(&m_pBuffer, m_lSize, &m_UserData);
 
         if (m_pBuffer == NULL)
+        {
+            pSample->Release();
+            *ppBuffer = NULL;
             return E_FAIL;
+        }
     }
 
-    pSample = (CSample*)*ppBuffer;
-    if (!gst_buffer_map(m_pBuffer, &m_MapInfo, GST_MAP_WRITE))
-        return hr;
-
-    pSample->m_pGstBuffer = m_pBuffer;
-    pSample->m_GstMapInfo = m_MapInfo;
-
-    hr = pSample->SetPointer(m_MapInfo.data, m_MapInfo.size);
+    hr = pSample->SetGstBuffer(m_pBuffer);
     m_pBuffer = NULL;
     if (FAILED(hr))
+    {
+        pSample->Release();
+        *ppBuffer = NULL;
         return hr;
+    }
 
     return S_OK;
 }
@@ -86,9 +89,11 @@ HRESULT CAllocator::ReleaseBuffer(IMediaSample *pBuffer)
     CSample *pSample = (CSample*)pBuffer;
     if (ReleaseSample != NULL)
     {
-        gst_buffer_unmap(pSample->m_pGstBuffer, &pSample->m_GstMapInfo);
-        ReleaseSample(pSample->m_pGstBuffer, &m_UserData);
-        pSample->m_pGstBuffer = NULL;
+        GstBuffer *pGstBuffer = pSample->TakeGstBuffer();
+        if (NULL != pGstBuffer)
+        {
+            ReleaseSample(pGstBuffer, &m_UserData);
+        }
     }
 
     hr = CBaseAllocator::ReleaseBuffer(pBuffer);
@@ -181,4 +186,34 @@ STDMETHODIMP CAllocator::SetProperties(ALLOCATOR_PROPERTIES* pRequest, ALLOCATOR
     pActual->cbPrefix = m_lPrefix = pRequest->cbPrefix;
 
     return S_OK;
+}
+
+HRESULT CSample::SetGstBuffer(GstBuffer *pGstBuffer)
+{
+    if (NULL == pGstBuffer)
+    {
+        return E_FAIL;
+    }
+
+    m_pGstBuffer = pGstBuffer;
+
+    if (!gst_buffer_map(pGstBuffer, &m_GstMapInfo, GST_MAP_WRITE))
+    {
+        return E_FAIL;
+    }
+    m_bGstBufferMapped = true;
+
+    return SetPointer(m_GstMapInfo.data, m_GstMapInfo.size);
+}
+
+GstBuffer *CSample::TakeGstBuffer()
+{
+    GstBuffer *ret = m_pGstBuffer;
+    if (NULL != m_pGstBuffer && m_bGstBufferMapped)
+    {
+        gst_buffer_unmap(m_pGstBuffer, &m_GstMapInfo);
+    }
+    m_pGstBuffer = NULL;
+    m_bGstBufferMapped = false;
+    return ret;
 }

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.h
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,9 +40,20 @@ struct sUserData
 class CSample : public CMediaSample
 {
 public:
-    CSample(TCHAR *pName, CBaseAllocator *pAllocator, HRESULT *phr) : CMediaSample(pName, pAllocator, phr) { m_pGstBuffer = NULL; }
+    CSample(TCHAR *pName, CBaseAllocator *pAllocator, HRESULT *phr)
+        : CMediaSample(pName, pAllocator, phr)
+    {
+        m_pGstBuffer = NULL;
+        m_bGstBufferMapped = false;
+    }
+
+    HRESULT SetGstBuffer(GstBuffer *pGstBuffer);
+    GstBuffer *TakeGstBuffer();
+
+private:
     GstBuffer *m_pGstBuffer;
     GstMapInfo m_GstMapInfo;
+    bool m_bGstBufferMapped;
 };
 
 class CAllocator : public CBaseAllocator
@@ -64,7 +75,6 @@ public:
 
 private:
     GstBuffer *m_pBuffer;
-    GstMapInfo m_MapInfo;
     sUserData m_UserData;
     void (*ReleaseSample)(GstBuffer *pBuffer, sUserData *pUserData);
     void (*GetGstBuffer)(GstBuffer **ppBuffer, long lSize, sUserData *pUserData); // This function will be called before GetBuffer() (before CBaseOutputPin::GetDeliveryBuffer()) if SetGstBuffer was not called

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Sink.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Sink.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -389,8 +389,7 @@ HRESULT CSink::DoRenderSampleInternal(IMediaSample *pMediaSample)
     if (pSample == NULL)
         return S_FALSE;
 
-    pBuffer = pSample->m_pGstBuffer;
-    pSample->m_pGstBuffer = NULL;
+    pBuffer = pSample->TakeGstBuffer();
     if (pBuffer == NULL)
         return S_FALSE;
 


### PR DESCRIPTION
This is the clean backport of "JDK-8389515: Memory leak in dshowwrapper - decoded buffers delivered by CSink are never unmapped" to jfx25u.

I'm backporting this because jfx25u is affected with the memory leak problem and for parity with Oracle.

The problem is reproduced before the fix and gone after the fix:
```
Java:   24.0.2 (OpenJDK 64-Bit Server VM)
JavaFX: 25.0.4-internal (runtime 25.0.4-internal+0-2026-08-06-143023)
460.5 MiB
3163.6 MiB
5849.0 MiB
8546.1 MiB
11266.2 MiB
13952.5 MiB
16649.8 MiB
19347.8 MiB
22060.6 MiB
24755.5 MiB
27448.6 MiB

Java:   24.0.2 (OpenJDK 64-Bit Server VM)
JavaFX: 25.0.4-internal (runtime 25.0.4-internal+0-2026-08-06-144848)
437.6 MiB
470.6 MiB
450.4 MiB
451.7 MiB
451.6 MiB
455.6 MiB
458.7 MiB
461.4 MiB
458.2 MiB
458.6 MiB
461.9 MiB
```
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8389515](https://bugs.openjdk.org/browse/JDK-8389515) needs maintainer approval

### Issue
 * [JDK-8389515](https://bugs.openjdk.org/browse/JDK-8389515): Memory leak in dshowwrapper - decoded buffers delivered by CSink are never unmapped (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx25u.git pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/jfx25u.git pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx25u/pull/63.diff">https://git.openjdk.org/jfx25u/pull/63.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx25u/pull/63#issuecomment-5213638471)
</details>
