### PR TITLE
8384522: Update libxml2 to 2.15.3

### DIFF
--- a/modules/javafx.web/src/main/legal/libxml2.md
+++ b/modules/javafx.web/src/main/legal/libxml2.md
@@ -1,4 +1,4 @@
-## xmlsoft.org: libxml2 v2.15.2
+## xmlsoft.org: libxml2 v2.15.3
 
 ### libxml2 License
 ```
@@ -86,23 +86,9 @@ Nick Wellnhofer
 
 Thanks to the following contributors:
 
-- gabriel desharnais
-- Benjamin Gilbert
-- Daniel Garcia Moreno
-- Herman Semenoff
-- Iván Chavero
-- Jayakrishna Menon
-- Michael Heilmann
-- Michal Privoznik
-- Mike Dalessio
-- Nathan
-- Niels Dossche
-- Peter Fordham
-- Petr Simecek
-- Sandino Araico Sanchez
-- Stéphane Cerveau
-- Steve Lhomme
-- Trevor Gamblin
-- ylwango613
-- Yun
+- Ariel Schon
+- Hieu Le Minh
+- James Lan
+- LCaliman
+- Yenya
 ```

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
@@ -15,21 +15,21 @@
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.15.2"
+#define LIBXML_DOTTED_VERSION "2.15.3"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21502
+#define LIBXML_VERSION 21503
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21502"
+#define LIBXML_VERSION_STRING "21503"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -44,7 +44,7 @@
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21502);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21503);
 
 /**
  * LIBXML_THREAD_ENABLED:

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
@@ -15,21 +15,21 @@
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.15.2"
+#define LIBXML_DOTTED_VERSION "2.15.3"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21502
+#define LIBXML_VERSION 21503
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21502"
+#define LIBXML_VERSION_STRING "21503"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -44,7 +44,7 @@
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21502);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21503);
 
 /**
  * LIBXML_THREAD_ENABLED:

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
@@ -1,5 +1,48 @@
 NEWS file for libxml2
 
+v2.15.3: Apr 15 2026
+
+### Security
+
+- parser: Pass userData to SAX text callbacks in xmlParseReference (type-confusion)
+- entities: copy children in xmlCopyEntity
+- c14n: Fix Type confusion in xmlC14NProcessAttrsAxis
+- python: Do not decref string after adding to the list (double-free / use-after-free)
+- c14n: Reuse tmp_str, xmlStrcat reallocates *cur (double-free)
+
+### Improvements
+
+- schemas: Fix relative schemaLocation resolution in XSI assembly in streaming mode
+- xmlreader: propagate reader resource loaders to validator parsers
+- python: Make python bindings python2 compatible
+- xmlregexp: Fix escape-sequence character range matching
+- xmlreader: Free input in xmlReaderForFd (memory-leak)
+- xmlstring: Free cur on every error for xmlStrncat (memory-leak)
+- catalog: Free xmlCatalogResolveCache on cleanup (memory leak)
+- Fix nanohttp.c build when --without-output
+- test: fix mismatched signed/unsigned comparison
+
+### Thanks
+
+Thanks to the following new contributors:
+
+- Ariel Schon
+- Hieu Le Minh
+- James Lan
+- LCaliman
+- Yenya
+
+### Full list of commits and contributors on this release
+
+13  Daniel Garcia Moreno
+ 2  Ariel Schon
+ 2  Hieu Le Minh
+ 1  James Lan
+ 1  Jan Alexander Steffens (heftig)
+ 1  LCaliman
+ 1  Yenya
+
+
 v2.15.2: Mar 03 2026
 
 ### Security

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/entities.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/entities.c
@@ -29,6 +29,7 @@
 #include "private/entities.h"
 #include "private/error.h"
 #include "private/io.h"
+#include "private/tree.h"
 
 #ifndef SIZE_MAX
   #define SIZE_MAX ((size_t) -1)
@@ -637,6 +638,14 @@ xmlCopyEntity(void *payload, const xmlChar *name ATTRIBUTE_UNUSED) {
         if (cur->URI == NULL)
             goto error;
     }
+    /* Handle XML_TEXT_NODE children for XML_ENTITY_DECL */
+    if (ent->children != NULL) {
+        cur->children = xmlStaticCopyNodeList(ent->children, cur->doc, (xmlNodePtr)cur);
+        /* Update last pointers */
+        cur->last = cur->children;
+        while (cur->last && cur->last->next) cur->last = cur->last->next;
+    }
+
     return(cur);
 
 error:

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/nanohttp.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/nanohttp.c
@@ -294,6 +294,7 @@ xmlIOHTTPClose (void *context ATTRIBUTE_UNUSED) {
     return 0;
 }
 
+#ifdef LIBXML_OUTPUT_ENABLED
 /**
  * @deprecated HTTP support was removed in 2.15.
  */
@@ -301,5 +302,6 @@ void
 xmlRegisterHTTPPostCallbacks(void) {
     xmlRegisterDefaultOutputCallbacks();
 }
+#endif
 
 #endif /* LIBXML_HTTP_STUBS_ENABLED */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parser.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parser.c
@@ -7261,10 +7261,10 @@ xmlParseReference(xmlParserCtxt *ctxt) {
             if ((cur->type == XML_TEXT_NODE) ||
                 (ctxt->options & XML_PARSE_NOCDATA)) {
                 if (ctxt->sax->characters != NULL)
-                    ctxt->sax->characters(ctxt, cur->content, len);
+                    ctxt->sax->characters(ctxt->userData, cur->content, len);
             } else {
                 if (ctxt->sax->cdataBlock != NULL)
-                    ctxt->sax->cdataBlock(ctxt, cur->content, len);
+                    ctxt->sax->cdataBlock(ctxt->userData, cur->content, len);
             }
 
             cur = cur->next;
@@ -7284,10 +7284,12 @@ xmlParseReference(xmlParserCtxt *ctxt) {
                 if ((cur->type == XML_TEXT_NODE) ||
                     (ctxt->options & XML_PARSE_NOCDATA)) {
                     if (ctxt->sax->characters != NULL)
-                        ctxt->sax->characters(ctxt, cur->content, len);
+                        ctxt->sax->characters(ctxt->userData, cur->content,
+                                              len);
                 } else {
                     if (ctxt->sax->cdataBlock != NULL)
-                        ctxt->sax->cdataBlock(ctxt, cur->content, len);
+                        ctxt->sax->cdataBlock(ctxt->userData, cur->content,
+                                              len);
                 }
 
                 break;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlreader.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlreader.c
@@ -4149,6 +4149,9 @@ xmlTextReaderRelaxNGValidateInternal(xmlTextReaderPtr reader,
         if ((reader->errorFunc != NULL) || (reader->sErrorFunc != NULL))
             xmlRelaxNGSetParserStructuredErrors(pctxt,
                     xmlTextReaderStructuredRelay, reader);
+        if (reader->resourceLoader != NULL)
+            xmlRelaxNGSetResourceLoader(pctxt, reader->resourceLoader,
+                                        reader->resourceCtxt);
         reader->rngSchemas = xmlRelaxNGParse(pctxt);
         xmlRelaxNGFreeParserCtxt(pctxt);
         if (reader->rngSchemas == NULL)
@@ -4239,6 +4242,9 @@ xmlTextReaderSchemaValidateInternal(xmlTextReaderPtr reader,
         if ((reader->errorFunc != NULL) || (reader->sErrorFunc != NULL))
             xmlSchemaSetParserStructuredErrors(pctxt,
                     xmlTextReaderStructuredRelay, reader);
+        if (reader->resourceLoader != NULL)
+            xmlSchemaSetResourceLoader(pctxt, reader->resourceLoader,
+                                       reader->resourceCtxt);
         reader->xsdSchemas = xmlSchemaParse(pctxt);
         xmlSchemaFreeParserCtxt(pctxt);
         if (reader->xsdSchemas == NULL)
@@ -5096,8 +5102,6 @@ xmlReaderForFd(int fd, const char *URL, const char *encoding, int options)
         xmlTextReaderErr(code, "failed to open fd");
         return(NULL);
     }
-    input->closecallback = NULL;
-
     reader = xmlNewTextReader(input, URL);
     if (reader == NULL) {
         xmlTextReaderErrMemory(NULL);
@@ -5353,8 +5357,6 @@ xmlReaderNewFd(xmlTextReader *reader, int fd,
         xmlTextReaderErr(code, "failed to open fd");
         return(-1);
     }
-    input->closecallback = NULL;
-
     if (xmlTextReaderSetup(reader, input, URL, encoding, options) < 0) {
         xmlTextReaderErrMemory(NULL);
         return(-1);

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlstring.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlstring.c
@@ -426,14 +426,21 @@ xmlStrncat(xmlChar *cur, const xmlChar *add, int len) {
 
     if ((add == NULL) || (len == 0))
         return(cur);
-    if (len < 0)
+
+    if (len < 0) {
+        if (cur != NULL)
+            xmlFree(cur);
         return(NULL);
+    }
+
     if (cur == NULL)
         return(xmlStrndup(add, len));
 
     size = xmlStrlen(cur);
-    if ((size < 0) || (size > INT_MAX - len))
+    if ((size < 0) || (size > INT_MAX - len)) {
+        xmlFree(cur);
         return(NULL);
+    }
     ret = (xmlChar *) xmlRealloc(cur, (size_t) size + len + 1);
     if (ret == NULL) {
         xmlFree(cur);

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
@@ -15,21 +15,21 @@
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.15.2undefined"
+#define LIBXML_DOTTED_VERSION "2.15.3undefined"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21502
+#define LIBXML_VERSION 21503
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21502"
+#define LIBXML_VERSION_STRING "21503"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -44,7 +44,7 @@
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21502);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21503);
 
 /**
  * LIBXML_THREAD_ENABLED:


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 24f07a9f from the openjdk/jfx repository.

The commit being backported was authored by Ambarish Rapte on 25 May 2026 and was reviewed by Kevin Rushforth and Jay Bhaskar.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8384522](https://bugs.openjdk.org/browse/JDK-8384522) needs maintainer approval

### Issue
 * [JDK-8384522](https://bugs.openjdk.org/browse/JDK-8384522): Update libxml2 to 2.15.3 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx25u.git pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.org/jfx25u.git pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx25u/pull/66.diff">https://git.openjdk.org/jfx25u/pull/66.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx25u/pull/66#issuecomment-5278143623)
</details>
