### PR TITLE
8360586: JavaFX build uses deprecated features that will be removed in gradle 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,10 @@ import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 import java.lang.Runtime.Version
 
+import org.gradle.process.ExecOperations
+
+def execOps = project.services.get(ExecOperations)
+
 /******************************************************************************
  *                              Utility methods                               *
  *****************************************************************************/
@@ -879,7 +883,8 @@ void fetchExternalTools(String configName, List packages, File destdir, boolean 
                     if (IS_LINUX || IS_MAC) {
                         // use native tar to support symlinks
                         pkgdir.mkdirs()
-                        exec {
+                        def execOps = project.services.get(ExecOperations)
+                        execOps.exec { spec ->
                             workingDir pkgdir
                             commandLine "tar", "zxf", "${srcball}"
                          }
@@ -961,7 +966,8 @@ void ant(String conf,   // platform configuration
 
     cmdArgs += target
 
-    exec {
+    def execOps = project.services.get(ExecOperations)
+    execOps.exec { spec ->
         workingDir = dir
         environment("JDK_HOME", JDK_HOME)
         environment("JAVA_HOME", JDK_HOME)
@@ -2019,7 +2025,7 @@ void addJCov(p, test) {
     test.doLast {
         def reportFile = p.file("build/reports/jcov/report.xml")
         if (reportFile.exists()) {
-            p.javaexec {
+            execOps.javaexec { spec ->
                 workingDir = p.file("build/reports/jcov")
                 classpath = p.files(p.configurations.testClasspath.files.find { it.name.startsWith('jcov') })
                 mainClass = "com.sun.tdk.jcov.Helper"
@@ -2543,7 +2549,7 @@ project(":graphics") {
                     futures.add(executor.submit(new Runnable() {
                         @Override public void run() {
                             try {
-                                exec {
+                                execOps.exec { spec ->
                                     commandLine cmd
                                 }
                             } finally {
@@ -2584,7 +2590,7 @@ project(":graphics") {
     // The GenAllDecoraShader.java class generates all the Decora shaders
     addJSL(project, "Decora", "com/sun/scenario/effect/impl/hw", decoraAddExports) { sourceDir, destinationDir ->
         [[fileName: "GenAllDecoraShaders", generator: "GenAllDecoraShaders", outputs: "-all"]].each { settings ->
-            javaexec {
+            execOps.javaexec { spec ->
                 executable = JAVA
                 workingDir = project.projectDir
                 mainClass = settings.generator
@@ -2679,7 +2685,7 @@ project(":graphics") {
         def inputFiles = fileTree(dir: sourceDir)
         inputFiles.include "**/*.jsl"
         inputFiles.each { file ->
-            javaexec {
+            execOps.javaexec { spec ->
                 executable = JAVA
                 workingDir = project.projectDir
                 mainClass = "CompileJSL"
@@ -2698,7 +2704,7 @@ project(":graphics") {
             def PASSTHROUGH_VS_SRC = file("src/main/native-prism-mtl/msl/PassThroughVS.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                exec {
+                execOps.exec { spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2714,7 +2720,7 @@ project(":graphics") {
             def CLEAR_RTT_VFS_SRC = file("src/main/native-prism-mtl/msl/ClearRttShaders.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                exec {
+                execOps.exec { spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2730,7 +2736,7 @@ project(":graphics") {
             def COMPUTE_KERNELS_SRC = file("src/main/native-prism-mtl/msl/ComputeKernels.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                exec {
+                execOps.exec { spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2746,7 +2752,7 @@ project(":graphics") {
             def PHONG_VS_SRC = file("src/main/native-prism-mtl/msl/PhongVS.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                exec {
+                execOps.exec { spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2762,7 +2768,7 @@ project(":graphics") {
             def PHONG_PS_SRC = file("src/main/native-prism-mtl/msl/PhongPS.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                exec {
+                execOps.exec { spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2785,7 +2791,7 @@ project(":graphics") {
             doLast {
                 mkdir "$buildDir/msl/com/sun/prism/mtl/msl"
                 def shaderFiles = fileTree(dir: "$buildDir/msl", include: "**/*.air")
-                exec {
+                execOps.exec { spec ->
                     commandLine("${metalLinker}")
                     shaderFiles.each { shaderFile ->
                         args += shaderFile
@@ -2942,7 +2948,7 @@ project(":controls") {
         cssFiles.each { css ->
             logger.info("converting CSS to BSS ${css}");
 
-            javaexec {
+            execOps.javaexec { spec ->
                 executable = JAVA
                 workingDir = project.projectDir
                 jvmArgs += patchModuleArgs
@@ -3348,7 +3354,7 @@ project(":media") {
             modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.graphics/build/classes/java/main"
             modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.base/build/classes/java/main"
 
-            exec {
+            execOps.exec { spec ->
                 commandLine("$JAVA");
                 args += patchModuleArgs
                 args += [ "--module-path=$modulePath" ]
@@ -3380,7 +3386,7 @@ project(":media") {
             }
 
             doLast {
-                exec {
+                execOps.exec { spec ->
                     commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/jfxmedia/projects/${projectDir}")
                     args("JAVA_HOME=${JDK_HOME}", "GENERATED_HEADERS_DIR=${generatedHeadersDir}",
                          "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=jfxmedia",
@@ -3409,7 +3415,7 @@ project(":media") {
             def buildGStreamer = task("build${t.capital}GStreamer") {
                 enabled = IS_COMPILE_MEDIA
                 doLast {
-                    exec {
+                    execOps.exec { spec ->
                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/gstreamer-lite")
                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=gstreamer-lite",
                              "ARCH=${ARCH_NAME}", "CC=${mediaProperties.compiler}",
@@ -3427,7 +3433,7 @@ project(":media") {
                 enabled = IS_COMPILE_MEDIA
 
                 doLast {
-                    exec {
+                    execOps.exec { spec ->
                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/fxplugins")
                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=fxplugins",
                              "ARCH=${ARCH_NAME}",
@@ -3535,11 +3541,11 @@ project(":media") {
                                 File cfgFile = file(configFile)
                                 if (!cfgFile.exists()) {
                                     // Add execute permissions to version.sh, otherwise build fails
-                                    exec {
+                                    execOps.exec { spec ->
                                         workingDir("$libavDir")
                                         commandLine("chmod", "+x", "version.sh")
                                     }
-                                    exec {
+                                    execOps.exec { spec ->
                                         workingDir("$libavDir")
                                         if (IS_BUILD_WORKING_LIBAV) {
                                             commandLine(cfgCMDArgs + commonCfgArgs + codecsCfgArgs)
@@ -3548,7 +3554,7 @@ project(":media") {
                                         }
                                     }
                                 }
-                                exec {
+                                execOps.exec { spec ->
                                     workingDir("$libavDir")
                                     commandLine("make")
                                 }
@@ -3603,11 +3609,11 @@ project(":media") {
                                         file.write(data, "UTF-8")
                                     }
                                     // Add execute permissions to version.sh, otherwise build fails
-                                    exec {
+                                    execOps.exec { spec ->
                                         workingDir("$libavDir")
                                         commandLine("chmod", "+x", "version.sh")
                                     }
-                                    exec {
+                                    execOps.exec { spec ->
                                         workingDir("$libavDir")
                                         if (IS_BUILD_WORKING_LIBAV) {
                                             commandLine(cfgCMDArgs + commonCfgArgs + codecsCfgArgs + extraCfgArgs)
@@ -3616,7 +3622,7 @@ project(":media") {
                                         }
                                     }
                                 }
-                                exec {
+                                execOps.exec { spec ->
                                     workingDir("$libavDir")
                                     commandLine("make")
                                 }
@@ -3677,7 +3683,7 @@ project(":media") {
                                     def versionFile = "${libavDir}/version.sh"
                                     File verFile = file(versionFile)
                                     if (verFile.exists()) {
-                                        exec {
+                                        execOps.exec { spec ->
                                             workingDir("$libavDir")
                                             commandLine("chmod", "+x", "version.sh")
                                         }
@@ -3685,7 +3691,7 @@ project(":media") {
                                         versionFile = "${libavDir}/ffbuild/version.sh"
                                         verFile = file(versionFile)
                                         if (verFile.exists()) {
-                                            exec {
+                                            execOps.exec { spec ->
                                                 workingDir("${libavDir}/ffbuild")
                                                 commandLine("chmod")
                                                 args += "+x"
@@ -3693,7 +3699,7 @@ project(":media") {
                                             }
                                         }
                                     }
-                                    exec {
+                                    execOps.exec { spec ->
                                         workingDir("$libavDir")
                                         if (IS_BUILD_WORKING_LIBAV) {
                                             commandLine(cfgCMDArgs + commonCfgArgs + codecsCfgArgs)
@@ -3702,7 +3708,7 @@ project(":media") {
                                         }
                                     }
                                 }
-                                exec {
+                                execOps.exec { spec ->
                                     workingDir("$libavDir")
                                     commandLine("make")
                                 }
@@ -3737,7 +3743,7 @@ project(":media") {
                                 def libavDir = "${project.ext.libav.basedir}-${version}"
                                 File dir = file(libavDir)
                                 if (dir.exists()) {
-                                    exec {
+                                    execOps.exec { spec ->
                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3752,7 +3758,7 @@ project(":media") {
                                 def libavDir = "${project.ext.libav.libavffmpeg.basedir}-${version}"
                                 File dir = file(libavDir)
                                 if (dir.exists()) {
-                                    exec {
+                                    execOps.exec { spec ->
                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3767,7 +3773,7 @@ project(":media") {
                                 def libavDir = "${project.ext.libav.ffmpeg.basedir}-${version}"
                                 File dir = file(libavDir)
                                 if (dir.exists()) {
-                                    exec {
+                                    execOps.exec { spec ->
                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3779,7 +3785,7 @@ project(":media") {
                             }
                         } else {
                             // Building fxavcodec plugin (libav plugin)
-                            exec {
+                            execOps.exec { spec ->
                                 commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                 args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                      "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3796,28 +3802,28 @@ project(":media") {
                     doLast {
                         def rcOutputDir = "${nativeOutputDir}/${buildType}"
                         mkdir rcOutputDir
-                        exec {
+                        execOps.exec { spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.glibRcFlags)
                             args("/Fo${rcOutputDir}/${WIN.media.glibRcFile}", WIN.media.rcSource)
                         }
 
-                        exec {
+                        execOps.exec { spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.gstreamerRcFlags)
                             args("/Fo${rcOutputDir}/${WIN.media.gstreamerRcFile}", WIN.media.rcSource)
                         }
 
-                        exec {
+                        execOps.exec { spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.fxpluginsRcFlags)
                             args("/Fo${rcOutputDir}/${WIN.media.fxpluginsRcFile}", WIN.media.rcSource)
                         }
 
-                        exec {
+                        execOps.exec { spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.jfxmediaRcFlags)
@@ -3829,7 +3835,7 @@ project(":media") {
                 def buildGlib = task("build${t.capital}Glib", dependsOn: [buildResources]) {
                     enabled = IS_COMPILE_MEDIA
                     doLast {
-                        exec {
+                        execOps.exec { spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/glib-lite")
                             args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=glib-lite",
@@ -3844,13 +3850,13 @@ project(":media") {
                 def buildGlib = task("build${t.capital}Glib") {
                     enabled = IS_COMPILE_MEDIA
                     doLast {
-                        exec {
+                        execOps.exec { spec ->
                             commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/libffi")
                             args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=ffi", "ARCH=$TARGET_ARCH")
                             args ("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}", "AR=${mediaProperties.ar}")
                         }
 
-                        exec {
+                        execOps.exec { spec ->
                             commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/glib-lite")
                             args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=glib-lite", "ARCH=$TARGET_ARCH")
                             args ("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}")
@@ -4035,13 +4041,13 @@ project(":web") {
             enabled =  (IS_COMPILE_WEBKIT)
 
             doLast {
-                exec {
+                execOps.exec { spec ->
                     workingDir("$webkitOutputDir")
                     commandLine("perl", "$projectDir/src/main/native/Tools/Scripts/set-webkit-configuration", "--$webkitConfig")
                     environment(["WEBKIT_OUTPUTDIR" : webkitOutputDir])
                 }
 
-                exec {
+                execOps.exec { spec ->
                     workingDir("$webkitOutputDir")
                     def cmakeArgs = "-DENABLE_TOOLS=1"
                     def makeArgs = "-j $NUM_COMPILE_THREADS"
@@ -5110,7 +5116,7 @@ compileTargets { t ->
             if (IS_WINDOWS && IS_USE_CYGWIN) {
                 doLast {
                     if (IS_CHMOD_ARTIFACTS) {
-                        exec {
+                        execOps.exec { spec ->
                             workingDir(sdkArtifactsDir)
                             commandLine("chmod", "-R", "755", ".")
                         }
@@ -5812,7 +5818,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { spec ->
                             def cmd = [ strip, stripArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5829,7 +5835,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { spec ->
                             def cmd = [ signCmd, signArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5887,7 +5893,7 @@ compileTargets { t ->
                     inputFiles.include("*.so")
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { spec ->
                             def cmd = [ strip, stripArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5904,7 +5910,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { spec ->
                             def cmd = [ signCmd, signArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5940,7 +5946,7 @@ compileTargets { t ->
                     inputFiles.include("*.so")
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { spec ->
                             def cmd = [ strip, stripArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5957,7 +5963,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { spec ->
                             def cmd = [ signCmd, signArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -6184,7 +6190,7 @@ compileTargets { t ->
                 doLast {
                     mkdir jmodsDir
                     delete(jmodFile);
-                    exec {
+                    execOps.exec { spec ->
                         commandLine(JMOD)
                         args("create")
                         args("--class-path")

--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -23,6 +23,10 @@
  * questions.
  */
 
+import org.gradle.process.ExecOperations
+
+def execOps = project.services.get(ExecOperations)
+
 ext.LINUX = [:]
 
 // Glass Gtk is built with GTK+ 3. It is not compatible with other major GTK versions (e.g., GTK 2 or GTK 4).
@@ -95,7 +99,7 @@ def gtk3LinkFlags = [ ];
 
 setupTools("linux_gtk3",
     { propFile ->
-        def checkGTK3Version = exec {
+        def checkGTK3Version = execOps.exec { spec ->
             commandLine "${toolchainDir}pkg-config", "--exists", "gtk+-3.0 >= " + gtk3MinVersion
             ignoreExitValue = true
         }
@@ -106,14 +110,14 @@ setupTools("linux_gtk3",
         }
 
         ByteArrayOutputStream results2 = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { spec ->
             commandLine("${toolchainDir}pkg-config", "--cflags", "gtk+-3.0", "gthread-2.0", "xtst", "gio-unix-2.0")
             setStandardOutput(results2);
         }
         propFile << "cflagsGTK3=" << results2.toString().trim() << "\n";
 
         ByteArrayOutputStream results4 = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { spec ->
             commandLine("${toolchainDir}pkg-config", "--libs", "gtk+-3.0", "gthread-2.0", "xtst", "gio-unix-2.0")
             setStandardOutput(results4);
         }
@@ -136,14 +140,14 @@ def pangoLinkFlags = [];
 setupTools("linux_pango_tools",
     { propFile ->
         ByteArrayOutputStream results = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { spec ->
             commandLine "${toolchainDir}pkg-config", "--cflags", "pangoft2"
             standardOutput = results
         }
         propFile << "cflags=" << results.toString().trim() << "\n";
 
         results = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { spec ->
             commandLine "${toolchainDir}pkg-config", "--libs", "pangoft2"
             standardOutput = results
         }
@@ -167,14 +171,14 @@ def freetypeLinkFlags = []
 setupTools("linux_freetype_tools",
     { propFile ->
         ByteArrayOutputStream results = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { spec ->
             commandLine "${toolchainDir}pkg-config", "--cflags", "freetype2"
             standardOutput = results
         }
         propFile << "cflags=" << results.toString().trim() << "\n";
 
         results = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { spec ->
             commandLine "${toolchainDir}pkg-config", "--libs", "freetype2"
             standardOutput = results
         }

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -23,6 +23,10 @@
  * questions.
  */
 
+import org.gradle.process.ExecOperations
+
+def execOps = project.services.get(ExecOperations)
+
 ext.MAC = [:]
 
 MAC.canBuild = IS_MAC && IS_64
@@ -71,7 +75,7 @@ setupTools("mac_tools",
         } else if (!file(defaultSdkPath).isDirectory()) {
             // Get list of all macosx sdks
             ByteArrayOutputStream results = new ByteArrayOutputStream();
-            def xcodeBuildResult = exec {
+            def xcodeBuildResult = execOps.exec { spec ->
                 commandLine("xcodebuild", "-version", "-showsdks");
                 setStandardOutput(results);
                 ignoreExitValue(true);
@@ -91,14 +95,14 @@ setupTools("mac_tools",
                 }
 
                 results = new ByteArrayOutputStream();
-                exec {
+                execOps.exec { spec ->
                     commandLine("xcodebuild", "-version", "-sdk", sdk, "Path");
                     setStandardOutput(results);
                 }
             } else {
                 // try with command line developer tools
                 results = new ByteArrayOutputStream();
-                exec {
+                execOps.exec { spec ->
                     commandLine("xcrun", "--show-sdk-path");
                     setStandardOutput(results);
                 }
@@ -178,7 +182,7 @@ if (hasProperty('toolchainDir')) {
 } else {
     toolchainDir = ""
     ByteArrayOutputStream path = new ByteArrayOutputStream();
-    exec {
+    execOps.exec { spec ->
         // xcrun -f --sdk macosx metal
         commandLine("xcrun", "-f", "--sdk", "macosx", "metal");
         setStandardOutput(path);
@@ -187,7 +191,7 @@ if (hasProperty('toolchainDir')) {
     metalCompiler = path.toString().trim();
 
     path = new ByteArrayOutputStream();
-    exec {
+    execOps.exec { spec ->
         // xcrun -f --sdk macosx metallib
         commandLine("xcrun", "-f", "--sdk", "macosx", "metallib");
         setStandardOutput(path);

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CCTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CCTask.groovy
@@ -26,6 +26,9 @@
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
 
 class CCTask extends NativeCompileTask {
     @Input String compiler;
@@ -33,6 +36,11 @@ class CCTask extends NativeCompileTask {
     @Optional @InputDirectory File headers;
     @Optional @Input Closure eachOutputFile; // will be given a File and must return a File
     @Input boolean exe = false;
+
+    @Inject
+    CCTask(ExecOperations execOperations) {
+        super(execOperations);
+    }
 
     protected File outputFile(File sourceFile) {
         final String outFileName = sourceFile.getName().substring(0, sourceFile.getName().lastIndexOf("."));
@@ -50,8 +58,8 @@ class CCTask extends NativeCompileTask {
 
         // TODO the PDB file is never being built -- maybe because it is only built during
         // debug builds, otherwise that flag is ignored "/Fd" or "-Fd"
-        project.exec({
-            commandLine(compiler);
+        execCompile { spec ->
+            spec.commandLine(compiler);
 
             // Add in any additional compilation params
             if (params != null) {
@@ -59,42 +67,42 @@ class CCTask extends NativeCompileTask {
                 if (sourceFile.name.endsWith(".cpp") || sourceFile.name.endsWith(".cc") || sourceFile.name.endsWith(".mm")) {
                     def stripped = params;
                     stripped.remove("-std=c99");
-                    args(stripped)
+                    spec.args(stripped)
                 } else {
-                    args(params)
+                    spec.args(params)
                 }
-            };
+            }
 
-            if (headers != null) args("-I$headers");
+            if (headers != null) spec.args("-I$headers");
 
             // Add the source roots in as include directories
             sourceRoots.each { root ->
                 final File file = root instanceof File ? (File) root : project.file(root)
-                if (file.isDirectory()) args("-I$file");
+                if (file.isDirectory()) spec.args("-I$file");
             }
 
             // Add the name of the source file to compile
             if (project.IS_WINDOWS) {
                 if (exe) {
                     final File exeFile = new File("$output/${lastDot > 0 ? outputFile.name.substring(0, lastDot) + '.exe' : outputFile.name + '.exe'}");
-                    args(/*"/Fd$pdbFile",*/ "/Fo$outputFile", "/Fe$exeFile", "$sourceFile")
+                    spec.args(/*"/Fd$pdbFile",*/ "/Fo$outputFile", "/Fe$exeFile", "$sourceFile")
                 } else {
-                    args(/*"/Fd$pdbFile",*/ "/Fo$outputFile", "$sourceFile");
+                    spec.args(/*"/Fd$pdbFile",*/ "/Fo$outputFile", "$sourceFile");
                 }
             } else {
-                args(/*"-Fd$pdbFile",*/ "-o", "$outputFile", "$sourceFile");
+                spec.args(/*"-Fd$pdbFile",*/ "-o", "$outputFile", "$sourceFile");
             }
 
             // Add any optional linker options -- used now rarely but can be
             // used for any cc task which isn't going to be followed by a
             // link task
             if (linkerOptions != null && !linkerOptions.isEmpty()) {
-                args(linkerOptions);
+                spec.args(linkerOptions);
             }
 
             if (project.IS_WINDOWS){
-                environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
+                spec.environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
             }
-        });
+        }
     }
 }

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileHLSLTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileHLSLTask.groovy
@@ -23,15 +23,30 @@
  * questions.
  */
 
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
 class CompileHLSLTask extends NativeCompileTask {
+    @Inject
+    CompileHLSLTask(ExecOperations execOperations) {
+        super(execOperations);
+    }
+
     protected File outputFile(File sourceFile) {
         new File("$output/${sourceFile.name.replace('.hlsl', '.obj')}");
     }
 
     protected void doCompile(File sourceFile, File outputFile){
-        project.exec({
-            commandLine = ["$project.FXC", "/nologo", "/T", "ps_3_0", "/Fo", "$outputFile", "$sourceFile"]
-            environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
-        });
+        execCompile { spec ->
+            spec.commandLine = [
+                "$project.FXC",
+                "/nologo",
+                "/T", "ps_3_0",
+                "/Fo", "$outputFile",
+                "$sourceFile"
+            ]
+            spec.environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
+        }
     }
 }

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileMSLTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileMSLTask.groovy
@@ -23,16 +23,32 @@
  * questions.
  */
 
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
 class CompileMSLTask extends NativeCompileTask {
+    @Inject
+    CompileMSLTask(ExecOperations execOperations) {
+        super(execOperations);
+    }
+
     protected File outputFile(File sourceFile) {
         new File("$output/${sourceFile.name.replace('.metal', '.air')}");
     }
 
     protected void doCompile(File sourceFile, File outputFile){
         def headerDir = 'gensrc/mtl-headers';
-        def includeDir = "$project.buildDir/$headerDir"
-        project.exec({
-            commandLine = ["${project.metalCompiler}", "-Wdeprecated", "-std=macos-metal2.4", "-I", "$includeDir", "-c", "$sourceFile", "-o", "$outputFile"]
-        });
+        def includeDir = "$project.buildDir/$headerDir";
+        execCompile { spec ->
+            spec.commandLine = [
+                "${project.metalCompiler}",
+                "-Wdeprecated",
+                "-std=macos-metal2.4",
+                "-I", "$includeDir",
+                "-c", "$sourceFile",
+                "-o", "$outputFile"
+            ]
+        }
     }
 }

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileResourceTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileResourceTask.groovy
@@ -24,10 +24,18 @@
  */
 
 import org.gradle.api.tasks.Input
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
 
 class CompileResourceTask extends NativeCompileTask {
     @Input List<String> rcParams = new ArrayList<String>();
     @Input String compiler;
+
+    @Inject
+    CompileResourceTask(ExecOperations execOperations) {
+        super(execOperations);
+    }
 
     protected File outputFile(File sourceFile) {
         final String outFileName = sourceFile.getName().substring(0, sourceFile.getName().lastIndexOf("."));
@@ -35,11 +43,11 @@ class CompileResourceTask extends NativeCompileTask {
     }
 
     protected void doCompile(File sourceFile, File outputFile){
-        project.exec({
-            commandLine(compiler);
-            if (rcParams) args(rcParams);
-            args("/Fo$outputFile", "$sourceFile");
-            environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
-        });
+        execCompile { spec ->
+            spec.commandLine(compiler);
+            if (rcParams) spec.args(rcParams);
+            spec.args("/Fo$outputFile", "$sourceFile");
+            spec.environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
+        }
     }
 }

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/ExportedSymbolsTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/ExportedSymbolsTask.groovy
@@ -29,12 +29,21 @@ import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
 
 class ExportedSymbolsTask extends DefaultTask {
     @OutputFile File outputFile;
     @InputDirectory File libDir;
     @Optional @Input List<String> excludes;
 
+    private final ExecOperations execOperations;
+
+    @Inject
+    ExportedSymbolsTask(ExecOperations execOperations) {
+        this.execOperations = execOperations;
+    }
 
     @TaskAction void generateExportedSymbols() {
         // Get symbols only from .a libraries
@@ -49,11 +58,11 @@ class ExportedSymbolsTask extends DefaultTask {
         def baos = new ByteArrayOutputStream();
 
         // Execute nm on .a libraries
-        project.exec({
-            commandLine("nm", "-jg");
-            args(libNames);
-            setStandardOutput(baos);
-        });
+        execOperations.exec { spec ->
+            spec.commandLine("nm", "-jg");
+            spec.args(libNames);
+            spec.setStandardOutput(baos);
+        };
 
         def bais = new ByteArrayInputStream(baos.toByteArray());
 

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/JavaHeaderTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/JavaHeaderTask.groovy
@@ -31,12 +31,22 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
 
 class JavaHeaderTask extends DefaultTask {
     @OutputDirectory File output;
     @Input List sourceRoots = new ArrayList();
     @Input FileCollection classpath;
     private final PatternFilterable patternSet = new PatternSet();
+
+    private final ExecOperations execOperations;
+
+    @Inject
+    JavaHeaderTask(ExecOperations execOperations) {
+        this.execOperations = execOperations;
+    }
 
 //    @InputFiles public void setSource(Object source) {
 //        sourceRoots.clear();
@@ -89,10 +99,10 @@ class JavaHeaderTask extends DefaultTask {
             })
         }
         // Execute javah
-        project.exec({
-            commandLine("$project.JAVAH", "-d", "$output", "-classpath", "${classpath.asPath}");
-            args(classNames);
-        });
+        execOperations.exec { spec ->
+            spec.commandLine("$project.JAVAH", "-d", "$output", "-classpath", "${classpath.asPath}");
+            spec.args(classNames);
+        }
     }
 }
 

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/LipoTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/LipoTask.groovy
@@ -27,11 +27,21 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 
+import javax.inject.Inject
 
 class LipoTask extends DefaultTask {
     @InputDirectory File libDir;
     @OutputFile File lib;
+
+    private final ExecOperations execOperations;
+
+    @Inject
+    LipoTask(ExecOperations execOperations) {
+        this.execOperations = execOperations;
+    }
+
     @TaskAction void compile() {
         List<String> libNames = [];
         List<File> files = libDir.listFiles();
@@ -43,10 +53,10 @@ class LipoTask extends DefaultTask {
             }
         }
         // Create a fat library (.a)
-        project.exec({
-            commandLine("lipo", "-create", "-output", "$lib");
-            args(libNames);
-        });
+        execOperations.exec { spec ->
+            spec.commandLine("lipo", "-create", "-output", "$lib");
+            spec.args(libNames);
+        }
     }
 }
 

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/NativeCompileTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/NativeCompileTask.groovy
@@ -23,6 +23,7 @@
  * questions.
  */
 
+import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -31,6 +32,10 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
@@ -45,6 +50,13 @@ class NativeCompileTask extends DefaultTask {
     @OutputDirectory File output;
     @InputFiles List<File> allFiles = [];
     private final PatternFilterable patternSet = new PatternSet();
+
+    private final ExecOperations execOperations;
+
+    @Inject
+    NativeCompileTask(ExecOperations execOperations) {
+        this.execOperations = execOperations;
+    }
 
     public NativeCompileTask source(Object... sources) {
         for (Object source : sources) {
@@ -77,6 +89,11 @@ class NativeCompileTask extends DefaultTask {
                 allFiles += file.isDirectory() ? file.listFiles() : file;
             }
         }
+    }
+
+    // Replacement for project.exec, subclasses call this.
+    protected void execCompile(Action<ExecSpec> action) {
+        execOperations.exec(action);
     }
 
     @TaskAction void compile() {

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -23,6 +23,10 @@
  * questions.
  */
 
+import org.gradle.process.ExecOperations
+
+def execOps = project.services.get(ExecOperations)
+
 ext.WIN = [:]
 
 WIN.canBuild = IS_WINDOWS
@@ -64,7 +68,7 @@ setupTools("windows_tools",
             // Create the properties file
             ByteArrayOutputStream results = new ByteArrayOutputStream();
             String winsdkDir = System.getenv().get("WINSDK_DIR");
-            exec({
+            execOps.exec { spec ->
                 environment([
                         "WINSDKPATH" : winsdkDir == null ? "" : winsdkDir,
                         "CONF"       : "/$CONF", // TODO does this mean the generated properties must be reset when in a different configuration?
@@ -73,7 +77,7 @@ setupTools("windows_tools",
                 ]);
                 commandLine("cmd", "/q", "/c", "buildSrc\\genVSproperties.bat");
                 setStandardOutput(results);
-            });
+            }
             BufferedReader reader = new BufferedReader(new StringReader(results.toString().trim()));
             reader.readLine();
             reader.readLine();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit c61e2697 from the openjdk/jfx repository.

The commit being backported was authored by Ambarish Rapte on 14 Oct 2025 and was reviewed by Kevin Rushforth and Joeri Sykora.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8360586](https://bugs.openjdk.org/browse/JDK-8360586) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8360586](https://bugs.openjdk.org/browse/JDK-8360586): JavaFX build uses deprecated features that will be removed in gradle 9 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx25u.git pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/jfx25u.git pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx25u/pull/69.diff">https://git.openjdk.org/jfx25u/pull/69.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx25u/pull/69#issuecomment-5341202253)
</details>
