### PR TITLE
8340564: [macOS] Intermittent build failure in native font with parallel compilation

### DIFF
--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CCTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CCTask.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,11 +65,11 @@ class CCTask extends NativeCompileTask {
             if (params != null) {
                 // A little hack. Only use the -std=c99 flag if compiling .c or .m
                 if (sourceFile.name.endsWith(".cpp") || sourceFile.name.endsWith(".cc") || sourceFile.name.endsWith(".mm")) {
-                    def stripped = params;
+                    def stripped = new ArrayList<String>(params);
                     stripped.remove("-std=c99");
                     spec.args(stripped)
                 } else {
-                    spec.args(params)
+                    spec.args(new ArrayList<String>(params));
                 }
             }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 2abb9a3b from the openjdk/jfx repository.

The commit being backported was authored by Kevin Rushforth on 12 Jun 2026 and was reviewed by Andy Goryachev and Ambarish Rapte.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8340564](https://bugs.openjdk.org/browse/JDK-8340564) needs maintainer approval

### Issue
 * [JDK-8340564](https://bugs.openjdk.org/browse/JDK-8340564): [macOS] Intermittent build failure in native font with parallel compilation (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx25u.git pull/71/head:pull/71` \
`$ git checkout pull/71`

Update a local copy of the PR: \
`$ git checkout pull/71` \
`$ git pull https://git.openjdk.org/jfx25u.git pull/71/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 71`

View PR using the GUI difftool: \
`$ git pr show -t 71`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx25u/pull/71.diff">https://git.openjdk.org/jfx25u/pull/71.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx25u/pull/71#issuecomment-5342237879)
</details>
