### PR TITLE
8386859: WebView crashes when calling document.startViewTransition()

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -378,6 +378,14 @@ void BitmapTexture::updateContents(NativeImage* frameImage, const IntRect& targe
 
 void BitmapTexture::updateContents(GraphicsLayer* sourceLayer, const IntRect& targetRect, const IntPoint& offset, float scale)
 {
+#if PLATFORM(JAVA)
+    // Java has no GL texture upload path. This was a no-op in BitmapTextureJava.
+    UNUSED_PARAM(sourceLayer);
+    UNUSED_PARAM(targetRect);
+    UNUSED_PARAM(offset);
+    UNUSED_PARAM(scale);
+    return;
+#else
     // Making an unconditionally unaccelerated buffer here is OK because this code
     // isn't used by any platforms that respect the accelerated bit.
     auto imageBuffer = ImageBuffer::create(targetRect.size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
@@ -400,6 +408,7 @@ void BitmapTexture::updateContents(GraphicsLayer* sourceLayer, const IntRect& ta
         return;
 
     updateContents(image.get(), targetRect, IntPoint());
+#endif
 }
 
 void BitmapTexture::initializeStencil()

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -244,7 +244,11 @@ void TextureMapper::releaseUnusedTexturesNow()
 
 ClipStack& TextureMapper::clipStack()
 {
+#if PLATFORM(JAVA)
+    return m_clipStack;
+#else
     return data().currentSurface ? data().currentSurface->clipStack() : m_clipStack;
+#endif
 }
 
 void TextureMapper::beginPainting(FlipY flipY, BitmapTexture* surface)
@@ -1400,7 +1404,11 @@ void TextureMapper::bindSurface(BitmapTexture *surface)
 
 BitmapTexture* TextureMapper::currentSurface()
 {
+#if PLATFORM(JAVA)
+    return nullptr;
+#else
     return data().currentSurface.get();
+#endif
 }
 
 bool TextureMapper::beginScissorClip(const TransformationMatrix& modelViewMatrix, const FloatRect& targetRect)
@@ -1506,6 +1514,9 @@ void TextureMapper::beginClip(const TransformationMatrix& modelViewMatrix, const
     // Increase stencilIndex and apply stencil testing.
     clipStack().setStencilIndex(stencilIndex * 2);
     clipStack().applyIfNeeded();
+#else
+    clipStack().push();
+    clipStack().intersect(enclosingIntRect(modelViewMatrix.mapRect(targetRect.rect())));
 #endif
 }
 
@@ -1569,6 +1580,9 @@ void TextureMapper::beginClip(const TransformationMatrix& modelViewMatrix, const
     // Increase stencilIndex and apply stencil testing.
     clipStack().setStencilIndex(stencilIndex * 2);
     clipStack().applyIfNeeded();
+#else
+    clipStack().push();
+    clipStack().intersect(modelViewMatrix.mapQuad(clipPath.bounds()).enclosingBoundingBox());
 #endif
 }
 
@@ -1581,7 +1595,9 @@ void TextureMapper::beginClipWithoutApplying(const TransformationMatrix& modelVi
 void TextureMapper::endClip()
 {
     clipStack().pop();
+#if !PLATFORM(JAVA)
     clipStack().applyIfNeeded();
+#endif
 }
 
 void TextureMapper::endClipWithoutApplying()
@@ -1596,14 +1612,23 @@ IntRect TextureMapper::clipBounds()
 
 IntSize TextureMapper::maxTextureSize() const
 {
+#if PLATFORM(JAVA)
+    return IntSize(maximumAllowedImageBufferDimension, maximumAllowedImageBufferDimension);
+#else
     return IntSize(data().maxTextureSize(), data().maxTextureSize());
+#endif
 }
 
 void TextureMapper::setDepthRange(double zNear, double zFar)
 {
+#if PLATFORM(JAVA)
+    UNUSED_PARAM(zNear);
+    UNUSED_PARAM(zFar);
+#else
     data().zNear = zNear;
     data().zFar = zFar;
     updateProjectionMatrix();
+#endif
 }
 
 std::pair<double, double> TextureMapper::depthRange() const

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -41,6 +41,10 @@
 typedef void *EGLImage;
 
 namespace WebCore {
+#if PLATFORM(JAVA)
+inline constexpr int maximumAllowedImageBufferDimension = 256;
+#endif
+
 class BitmapTexture;
 class ClipPath;
 class TextureMapperGLData;

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapperJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapperJava.cpp
@@ -38,15 +38,13 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextureMapperJava);
 
-static const int s_maximumAllowedImageBufferDimension = 256;
-
 TextureMapperJava::TextureMapperJava()
 {
 }
 
 IntSize TextureMapperJava::maxTextureSize() const
 {
-    return IntSize(s_maximumAllowedImageBufferDimension, s_maximumAllowedImageBufferDimension);
+    return IntSize(maximumAllowedImageBufferDimension, maximumAllowedImageBufferDimension);
 }
 
 void TextureMapperJava::beginClip(const TransformationMatrix& matrix, const FloatRoundedRect& rect)

--- a/tests/system/src/test/java/test/javafx/scene/web/TextureMapperTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/TextureMapperTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import test.util.Util;
+
+public class TextureMapperTest {
+    private static final CountDownLatch launchLatch = new CountDownLatch(1);
+
+    private static TextureMapperTestApp textureMapperTestApp;
+    private WebView webView;
+
+    public static class TextureMapperTestApp extends Application {
+        private Stage primaryStage;
+
+        @Override
+        public void init() {
+            TextureMapperTest.textureMapperTestApp = this;
+        }
+
+        @Override
+        public void start(Stage primaryStage) {
+            Platform.setImplicitExit(false);
+            this.primaryStage = primaryStage;
+            launchLatch.countDown();
+        }
+    }
+
+    @BeforeAll
+    public static void setupOnce() {
+        Util.launch(launchLatch, TextureMapperTestApp.class);
+        assertTrue(Util.await(launchLatch), "Timeout waiting for FX runtime to start");
+    }
+
+    @AfterAll
+    public static void tearDownOnce() {
+        Util.shutdown();
+    }
+
+    @BeforeEach
+    public void setupTestObjects() {
+        Util.runAndWait(() -> {
+            webView = new WebView();
+            textureMapperTestApp.primaryStage.setScene(new Scene(webView, 800, 600));
+            textureMapperTestApp.primaryStage.show();
+        });
+    }
+
+    /**
+     * @test
+     * @bug 8386859
+     * @summary Verify that a view transition does not crash the Java TextureMapper path.
+     */
+    @Test
+    public void testViewTransitionDoesNotCrashTextureMapper() {
+        CountDownLatch transitionStarted = new CountDownLatch(1);
+
+        Util.runAndWait(() -> {
+            WebEngine engine = webView.getEngine();
+            engine.getLoadWorker().stateProperty().addListener((obs, oldState, newState) -> {
+                if (newState == SUCCEEDED) {
+                    engine.executeScript("if (document.startViewTransition) { document.startViewTransition(function() {}); }");
+                    transitionStarted.countDown();
+                }
+            });
+            engine.loadContent("<html></html>", "text/html");
+        });
+
+        assertTrue(Util.await(transitionStarted), "Timeout waiting for the view transition to start");
+        Util.sleep(500);
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [caa8403b](https://github.com/openjdk/jfx/commit/caa8403b201ab027e5dbb5bb054f5ee3042e8928) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Jay Bhaskar on 10 Aug 2026 and was reviewed by Kevin Rushforth and Ambarish Rapte.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8386859](https://bugs.openjdk.org/browse/JDK-8386859) needs maintainer approval

### Issue
 * [JDK-8386859](https://bugs.openjdk.org/browse/JDK-8386859): WebView crashes when calling document.startViewTransition() (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx25u.git pull/73/head:pull/73` \
`$ git checkout pull/73`

Update a local copy of the PR: \
`$ git checkout pull/73` \
`$ git pull https://git.openjdk.org/jfx25u.git pull/73/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 73`

View PR using the GUI difftool: \
`$ git pr show -t 73`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx25u/pull/73.diff">https://git.openjdk.org/jfx25u/pull/73.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx25u/pull/73#issuecomment-5394099851)
</details>
